### PR TITLE
Bugfix/volume spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Fix volumes specification handling. It's now possible to mount one host path multiple times
+  to different locations in the container image (f.e. with different access modes) as this is
+  possible with `docker run`.
 
 ## [0.3.10] - 2018-05-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+## [0.3.11] - 2018-05-27
 ### Fixed
 - Fix volumes specification handling. It's now possible to mount one host path multiple times
   to different locations in the container image (f.e. with different access modes) as this is
   possible with `docker run`.
 
-## [0.3.10] - 2018-05-23
+## [0.3.10] - 2018-05-26
 ### Added
 - Added support for `--tmpfs` (as in `docker run`) which allows to mount temporary directories
   inside of docker containers
@@ -71,7 +74,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Generate `.gitignore` using http://gitignore.io website.
 - Publish the project under MIT license.
 
-[Unreleased]: https://github.com/boon-code/docker-inside/compare/0.3.10...HEAD
+[Unreleased]: https://github.com/boon-code/docker-inside/compare/0.3.11...HEAD
+[0.3.11]: https://github.com/boon-code/docker-inside/compare/0.3.10...0.3.11
 [0.3.10]: https://github.com/boon-code/docker-inside/compare/0.3.9...0.3.10
 [0.3.9]: https://github.com/boon-code/docker-inside/compare/0.3.8...0.3.9
 [0.3.8]: https://github.com/boon-code/docker-inside/compare/0.3.7...0.3.8

--- a/dockerinside/__init__.py
+++ b/dockerinside/__init__.py
@@ -401,7 +401,7 @@ class DockerInsideApp(dockerutils.BasicDockerApp):
         ports = dict(dockerutils.port_list_to_dict(self._args.ports))
         env = self._prepare_environment(image_info)
         cmd = self._prepare_command(image_info)
-        volumes = dict(self.volume_args_to_dict(self._args.volumes))
+        volumes = self.volume_args_to_list(self._args.volumes)
         workdir = self._args.workdir
         if self._args.mount_workdir:
             wd_spec = dockerutils.normalize_volume_spec(self._args.mount_workdir)

--- a/dockerinside/dockerutils.py
+++ b/dockerinside/dockerutils.py
@@ -222,12 +222,12 @@ class BasicDockerApp(object):
             raise InvalidContainerState(cname, status)
 
     @staticmethod
-    def volume_args_to_dict(args):
-        d = dict()
+    def volume_args_to_list(args):
+        l = list()
         for i in args:
             tmp = normalize_volume_spec(i)
-            d[tmp[0]] = dict(bind=tmp[1], mode=tmp[2])
-        return d
+            l.append("{0}:{1}:{2}".format(*tmp))
+        return l
 
     def __init__(self, log, env=None):
         self._log = log

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import datetime
 YEAR = datetime.date.today().year
 
 __author__ = "Manuel Huber"
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 __license__ = "MIT"
 __copyright__ = u'%s, Manuel Huber' % YEAR
 


### PR DESCRIPTION
# Fixed
- Fix volumes specification handling. It's now possible to mount one host path multiple times
  to different locations in the container image (f.e. with different access modes) as this is
  possible with `docker run`.